### PR TITLE
AbstractController reduce dependecy by creating factory and config add 

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/presentation/Dockerfile
+++ b/presentation/Dockerfile
@@ -1,0 +1,38 @@
+# Stage 1: Build presentation-dev
+FROM gradle:8.7 AS build
+
+
+# Create presentation directory
+RUN mkdir -p /app/presentation
+
+# Set docker container working directory
+WORKDIR /app/presentation
+
+# Verify the directory creation
+RUN ls -la /app
+
+# Copy gradle wrapper and build files
+COPY gradle /app/presentation/gradle
+COPY gradlew /app/presentation/
+COPY build.gradle.kts /app/presentation/
+COPY settings.gradle.kts /app/presentation/
+COPY src /app/presentation/src
+RUN ./gradlew bootJar
+
+# Check if the JAR file is created (optional)
+RUN ls /app/presentation/build/libs
+
+# Stage 2: Create a minimal runtime image
+FROM amazoncorretto:17
+
+# Set working directory
+WORKDIR /app/presentation
+
+# Copy the JAR file from the build stage
+COPY --from=build /app/presentation/build/libs/*.jar /app/presentation/presentation-dev.jar
+
+# Expose the application port
+EXPOSE 9090
+
+# Command to run the application with a specific Spring profile
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=dev", "/app/presentation/presentation-dev.jar"]

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
 	java
 	id("org.springframework.boot") version "3.3.0"
@@ -22,7 +24,7 @@ repositories {
 }
 
 dependencies {
-	implementation("com.mysql:mysql-connector-j:8.3.0") // mariadb connector
+	implementation("org.mariadb.jdbc:mariadb-java-client:3.3.3")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive") // redis
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.3.0") // jpa
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
@@ -40,4 +42,16 @@ dependencies {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+	// Disable test execution
+	enabled = false
+}
+
+// Exclude test classes from the JAR file
+tasks.withType<Jar> {
+	// Exclude test classes
+	exclude("**/test/**")
+}
+
+tasks.withType<BootJar> {
+	mainClass.set("com.spring_greens.presentation.PresentationApplication")
 }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.projectreactor:reactor-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	implementation("org.springframework.boot:spring-boot-starter-logging")
+	implementation("org.springframework.boot:spring-boot-starter-logging") // slf4j + logback
 	testImplementation("org.mockito:mockito-junit-jupiter")
 }
 

--- a/presentation/docker-compose.dev.yml
+++ b/presentation/docker-compose.dev.yml
@@ -1,0 +1,65 @@
+version: '3.8'
+
+# Defined web container service
+services:
+
+  # create container for nginx
+  nginx:
+    # image tag perform defined name and tag if local build file. or not pull specific file docker registry or hub.
+    image: nginx:latest
+    ports:
+      - "80:80"
+    networks:
+      - presentation-network
+
+
+
+  # create container for spring boot
+  web:
+    # need to docker file to build image
+    # make build context
+    build:
+      # context means that where dockerfile is located.
+      # context : . means current directory.
+      # dockerfile : Docker file located on current directory(docker)
+      context: .
+      dockerfile: Dockerfile
+
+    # Defined image name and tag
+    image: itstime0809/spring_greens_presentation:latest
+    # Defined spring boot ports
+    ports:
+      - "9090:8080"
+    # Defined environment profile for dev environment.
+    env_file:
+      # Defined ec2 instance presentation.env file path
+      - /home/ec2-user/presentation.env
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+
+    # order execute services
+    depends_on:
+      - redis
+
+    # Defined custom network
+    # Available connect between container
+    networks:
+      - presentation-network
+
+
+  # create container for redis
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    networks:
+      - presentation-network
+    volumes:
+      - /home/ec2-user/redis.conf:/usr/local/etc/redis/redis.conf
+
+# Setting presentation custom network
+# driver : bridge docker base network
+# docker can connect each docker container to virtual bridge network.
+networks:
+  presentation-network:
+    driver: bridge

--- a/presentation/src/main/java/com/spring_greens/presentation/global/api/ApiResponse.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/api/ApiResponse.java
@@ -37,6 +37,7 @@ public class ApiResponse<T> {
                 ApiMessage.FAIL.getResponseMessage(),
                 data);
     }
+
     public static <T> ApiResponse<T> fail(@Nullable String message, @Nullable final T data) {
         if(message == null || message.isEmpty()) {
             message = ApiMessage.FAIL.getResponseMessage();

--- a/presentation/src/main/java/com/spring_greens/presentation/global/controller/AbstractBaseController.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/controller/AbstractBaseController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * This is abstract class for MapController and MainController. <br>
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 @Slf4j
 @RequiredArgsConstructor
+@RestController
 public abstract class AbstractBaseController {
     protected final ConverterFactory converterFactory;
     protected final ServiceFactory serviceFactory;

--- a/presentation/src/main/java/com/spring_greens/presentation/global/controller/AbstractBaseController.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/controller/AbstractBaseController.java
@@ -1,10 +1,10 @@
 package com.spring_greens.presentation.global.controller;
 
 import com.spring_greens.presentation.global.api.ApiResponse;
-import com.spring_greens.presentation.global.redis.service.RedisService;
-import com.spring_greens.presentation.mall.service.ifs.MallService;
+import com.spring_greens.presentation.global.factory.converter.ifs.ConverterFactory;
+import com.spring_greens.presentation.global.factory.service.ifs.ServiceFactory;
 import com.spring_greens.presentation.product.dto.redis.request.RedisProductRequest;
-import com.spring_greens.presentation.product.dto.redis.response.RedisProductResponse;
+import com.spring_greens.presentation.product.dto.redis.response.ifs.RedisProductResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,15 +28,19 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Slf4j
 @RequiredArgsConstructor
 public abstract class AbstractBaseController {
-    protected final MallService mallService;
-    protected final RedisService redisService;
+    protected final ConverterFactory converterFactory;
+    protected final ServiceFactory serviceFactory;
 
     @GetMapping("/get/products/{domain}/{mall_name}")
     @Operation(summary="상품 호출하기 메인")
     protected ApiResponse<RedisProductResponse> getProductsOfMall(@PathVariable("domain") String domain,
                                                                     @PathVariable("mall_name") String mallName) {
-        RedisProductRequest redisProductRequest = RedisProductRequest.builder().domain(domain).mallName(mallName).build();
-        RedisProductResponse product = redisService.getProductsFromRedisUsingKey(redisProductRequest);
+
+        RedisProductRequest redisProductRequest = converterFactory.getRedisConverter().createRequest(domain, mallName);
+        RedisProductResponse product = serviceFactory.getRedisService().getProductsFromRedisUsingKey(redisProductRequest);
         return ApiResponse.ok(product);
     }
 }
+
+
+

--- a/presentation/src/main/java/com/spring_greens/presentation/global/exception/CommonException.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/exception/CommonException.java
@@ -11,8 +11,5 @@ public abstract class CommonException extends RuntimeException{
             super(message);
         }
 
-        public CustomNullPointerException() {
-            this("Error data is null");
-        }
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/global/factory/converter/ConverterFactoryImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/factory/converter/ConverterFactoryImpl.java
@@ -1,0 +1,40 @@
+package com.spring_greens.presentation.global.factory.converter;
+
+import com.spring_greens.presentation.global.factory.converter.ifs.ConverterFactory;
+import com.spring_greens.presentation.global.redis.converter.ifs.RedisConverter;
+import com.spring_greens.presentation.map.converter.ifs.MallConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * ConverterFactory purpose is to break dependency of controller. <br>
+ * if converterFactory is not exist, AbstractBaseController has many of service bean and converter etc. <br>
+ * each of controller need to initialize bean by using constructor. <br>
+ * in this case, each controller increases the number of parameters to constructor. <br>
+ * <br>
+ * let's assume one situation, we have so many controller that contained many services. <br>
+ * if controller is changed or deleted, we have to change each of controller. <br>
+ *
+ * In order to prevent this, I create converter factory <br>
+ * as a result, this way reduces the dependence between controller and each bean. <br>
+ * @author itstime0809
+ */
+
+@Component
+@RequiredArgsConstructor
+public class ConverterFactoryImpl implements ConverterFactory {
+    @Qualifier(value = "redisConverterImpl")
+    private final RedisConverter redisConverter;
+    @Qualifier(value = "mallConverterImpl")
+    private final MallConverter mallConverter;
+    @Override
+    public MallConverter getMallConverter() {
+        return mallConverter;
+    }
+
+    @Override
+    public RedisConverter getRedisConverter() {
+        return redisConverter;
+    }
+}

--- a/presentation/src/main/java/com/spring_greens/presentation/global/factory/converter/ifs/ConverterFactory.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/factory/converter/ifs/ConverterFactory.java
@@ -1,0 +1,9 @@
+package com.spring_greens.presentation.global.factory.converter.ifs;
+
+import com.spring_greens.presentation.global.redis.converter.ifs.RedisConverter;
+import com.spring_greens.presentation.map.converter.ifs.MallConverter;
+
+public interface ConverterFactory {
+    MallConverter getMallConverter();
+    RedisConverter getRedisConverter();
+}

--- a/presentation/src/main/java/com/spring_greens/presentation/global/factory/service/ServiceFactoryImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/factory/service/ServiceFactoryImpl.java
@@ -1,0 +1,36 @@
+package com.spring_greens.presentation.global.factory.service;
+
+import com.spring_greens.presentation.global.factory.service.ifs.ServiceFactory;
+import com.spring_greens.presentation.global.redis.service.RedisService;
+import com.spring_greens.presentation.mall.service.ifs.MallService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * ConverterFactory purpose is to break dependency of controller. <br>
+ * if converterFactory is not exist, AbstractBaseController has many of service bean and converter etc. <br>
+ * each of controller need to initialize bean by using constructor. <br>
+ * in this case, each controller increases the number of parameters to constructor. <br>
+ * <br>
+ * let's assume one situation, we have so many controller that contained many services. <br>
+ * if controller is changed or deleted, we have to change each of controller. <br>
+ *
+ * In order to prevent this, I create converter factory <br>
+ * as a result, this way reduces the dependence between controller and each bean. <br>
+ * @author itstime0809
+ */
+@Component
+@RequiredArgsConstructor
+public class ServiceFactoryImpl implements ServiceFactory {
+    private final RedisService redisService;
+    private final MallService mallService;
+    @Override
+    public RedisService getRedisService() {
+        return redisService;
+    }
+
+    @Override
+    public MallService getMallService() {
+        return mallService;
+    }
+}

--- a/presentation/src/main/java/com/spring_greens/presentation/global/factory/service/ifs/ServiceFactory.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/factory/service/ifs/ServiceFactory.java
@@ -1,0 +1,10 @@
+package com.spring_greens.presentation.global.factory.service.ifs;
+
+import com.spring_greens.presentation.global.redis.service.RedisService;
+import com.spring_greens.presentation.mall.service.ifs.MallService;
+
+public interface ServiceFactory {
+    RedisService getRedisService();
+
+    MallService getMallService();
+}

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/converter/RedisConverterImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/converter/RedisConverterImpl.java
@@ -1,14 +1,15 @@
-package com.spring_greens.presentation.product.converter;
+package com.spring_greens.presentation.global.redis.converter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.spring_greens.presentation.global.enums.Domain;
-import com.spring_greens.presentation.product.converter.ifs.RedisConverter;
+import com.spring_greens.presentation.global.redis.converter.ifs.RedisConverter;
 import com.spring_greens.presentation.product.dto.redis.DeserializedRedisProduct;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisProductInformation;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisShopInformation;
 import com.spring_greens.presentation.product.dto.redis.information.MapRedisProductInformation;
+import com.spring_greens.presentation.product.dto.redis.request.RedisProductRequest;
 import com.spring_greens.presentation.product.dto.redis.response.MapRedisProductResponse;
-import com.spring_greens.presentation.product.dto.redis.response.RedisProductResponse;
+import com.spring_greens.presentation.product.dto.redis.response.ifs.RedisProductResponse;
 import com.spring_greens.presentation.shop.dto.information.MapRedisShopInformation;
 import org.springframework.stereotype.Component;
 
@@ -16,16 +17,26 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 
-/**
- * Implementation of RedisProductResponseConverter. <br>
- * this performs convert method and return RedisProduct type. <br>
- *
- * @author itsitme0809
- */
-@Component
-public class RedisProductConverterImpl implements RedisConverter {
 
-    private MapRedisProductResponse convertMapRedisProductResponse(DeserializedRedisProduct deserializedRedisProduct) {
+@Component
+public class RedisConverterImpl implements RedisConverter {
+    @Override
+    public RedisProductResponse createResponse(String domain, DeserializedRedisProduct deserializedRedisProduct) {
+        if(domain.equals(Domain.MAP.getDomain())) {
+            return this.convertMapRedisProductResponse(deserializedRedisProduct);
+        }
+        return null;
+    }
+
+    @Override
+    public RedisProductRequest createRequest(String domain, String mallName) {
+        return RedisProductRequest.builder().domain(domain).mallName(mallName).build();
+    }
+
+
+
+    @Override
+    public MapRedisProductResponse convertMapRedisProductResponse(DeserializedRedisProduct deserializedRedisProduct) {
         List<MapRedisShopInformation> mapRedisShopInformationList =
                 deserializedRedisProduct.getShop_list().stream().map(shopInfo ->
                         MapRedisShopInformation.builder()
@@ -56,18 +67,6 @@ public class RedisProductConverterImpl implements RedisConverter {
     }
 
     @Override
-    public DeserializedRedisShopInformation convertDeserializedRedisShopInformation(JsonNode jsonNode, List<DeserializedRedisProductInformation> deserializedRedisProductInformationList) {
-        return DeserializedRedisShopInformation
-                .builder()
-                .shop_id(jsonNode.get("shop_id").asLong())
-                .shop_name(jsonNode.get("shop_name").asText())
-                .shop_contact(jsonNode.get("shop_contact").asText())
-                .shop_address_details(jsonNode.get("shop_address_details").asText())
-                .product(deserializedRedisProductInformationList)
-                .build();
-    }
-
-    @Override
     public DeserializedRedisProductInformation convertDeserializedRedisProductInformation(JsonNode jsonNode){
         return DeserializedRedisProductInformation
                 .builder()
@@ -83,10 +82,16 @@ public class RedisProductConverterImpl implements RedisConverter {
     }
 
     @Override
-    public RedisProductResponse createResponse(String domain, DeserializedRedisProduct deserializedRedisProduct) {
-        if(domain.equals(Domain.MAP.getDomain())) {
-            return this.convertMapRedisProductResponse(deserializedRedisProduct);
-        }
-        return null;
+    public DeserializedRedisShopInformation convertDeserializedRedisShopInformation(JsonNode jsonNode, List<DeserializedRedisProductInformation> deserializedRedisProductInformationList) {
+        return DeserializedRedisShopInformation
+                .builder()
+                .shop_id(jsonNode.get("shop_id").asLong())
+                .shop_name(jsonNode.get("shop_name").asText())
+                .shop_contact(jsonNode.get("shop_contact").asText())
+                .shop_address_details(jsonNode.get("shop_address_details").asText())
+                .product(deserializedRedisProductInformationList)
+                .build();
     }
+
+
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/converter/ifs/RedisConverter.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/converter/ifs/RedisConverter.java
@@ -1,17 +1,24 @@
-package com.spring_greens.presentation.product.converter.ifs;
+package com.spring_greens.presentation.global.redis.converter.ifs;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.spring_greens.presentation.product.dto.redis.DeserializedRedisProduct;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisProductInformation;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisShopInformation;
-import com.spring_greens.presentation.product.dto.redis.response.RedisProductResponse;
+import com.spring_greens.presentation.product.dto.redis.request.RedisProductRequest;
+import com.spring_greens.presentation.product.dto.redis.response.MapRedisProductResponse;
+import com.spring_greens.presentation.product.dto.redis.response.ifs.RedisProductResponse;
 
 import java.util.List;
 
-public interface RedisConverter  {
-
+public interface RedisConverter{
     RedisProductResponse createResponse(String domain, DeserializedRedisProduct deserializedRedisProduct);
+    RedisProductRequest createRequest(String domain, String mallName);
+
+    MapRedisProductResponse convertMapRedisProductResponse(DeserializedRedisProduct deserializedRedisProduct);
+
     DeserializedRedisProduct convertDeserializedRedisProduct(JsonNode jsonNode, List<DeserializedRedisShopInformation> deserializedRedisShopInformationList);
-    DeserializedRedisShopInformation convertDeserializedRedisShopInformation(JsonNode jsonNode, List<DeserializedRedisProductInformation> deserializedRedisProductInformationList);
+
     DeserializedRedisProductInformation convertDeserializedRedisProductInformation(JsonNode jsonNode);
+
+    DeserializedRedisShopInformation convertDeserializedRedisShopInformation(JsonNode jsonNode, List<DeserializedRedisProductInformation> deserializedRedisProductInformationList);
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/exception/RedisException.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/exception/RedisException.java
@@ -1,7 +1,5 @@
 package com.spring_greens.presentation.global.redis.exception;
 
-import io.lettuce.core.models.role.RedisInstance;
-
 public abstract class RedisException extends RuntimeException{
     public RedisException(String message) {
         super(message);
@@ -21,5 +19,9 @@ public abstract class RedisException extends RuntimeException{
 
     public static class RedisIllegalArgumentException extends RedisException {
         public RedisIllegalArgumentException(String message) { super(message);}
+    }
+
+    public static class RedisIOException extends RedisException {
+        public RedisIOException(String message) {super(message);}
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/manager/RedisRepositoryImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/manager/RedisRepositoryImpl.java
@@ -8,7 +8,7 @@ import com.spring_greens.presentation.product.repository.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
 /**
  * TemplateManager contains RedisTemplate for Json, Hash. <br>
@@ -17,9 +17,9 @@ import org.springframework.stereotype.Component;
  * @author itstime0809
  */
 @Slf4j
-@Component
+@Repository
 @RequiredArgsConstructor
-public class RedisTemplateManager implements RedisRepository {
+public class RedisRepositoryImpl implements RedisRepository {
 
     private final RedisTemplate<String, Object> redisJsonTemplate;
     private final ObjectMapper objectMapper;

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/service/RedisService.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/service/RedisService.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.spring_greens.presentation.global.exception.CommonException;
 import com.spring_greens.presentation.global.redis.exception.RedisException;
 import com.spring_greens.presentation.global.redis.validation.ifs.RedisValidator;
-import com.spring_greens.presentation.product.converter.ifs.RedisConverter;
+import com.spring_greens.presentation.global.redis.converter.ifs.RedisConverter;
 import com.spring_greens.presentation.product.dto.redis.DeserializedRedisProduct;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisProductInformation;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisShopInformation;
 import com.spring_greens.presentation.product.dto.redis.request.RedisProductRequest;
-import com.spring_greens.presentation.product.dto.redis.response.RedisProductResponse;
+import com.spring_greens.presentation.product.dto.redis.response.ifs.RedisProductResponse;
 import com.spring_greens.presentation.product.repository.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class RedisService {
-    private final RedisRepository redisTemplateManager;
+    private final RedisRepository redisRepository;
     private final RedisConverter redisConverter;
     private final RedisValidator redisValidator;
 
@@ -36,18 +36,21 @@ public class RedisService {
         try {
             DeserializedRedisProduct deserializedRedisProduct = null;
             // 1. 파라미터 검증
-            if(validateRedisProductRequestParameter(redisProductRequest)) {
+            if(validateRedisProductRequest(redisProductRequest)) {
                 // 2. 상품 URL 가공
-                deserializedRedisProduct = modifyImageUrl(getProduct(redisProductRequest));
+                deserializedRedisProduct = modifyImageUrl(getProduct(redisProductRequest.getMallName()));
             }
             // 3. 상품 반환
             return convertToResponse(redisProductRequest.getDomain(), deserializedRedisProduct);
 
         } catch (NullPointerException e) {
+            log.error("Argument is null : {}", e.getMessage(), e);
             throw new CommonException.CustomNullPointerException(e.getMessage());
         } catch (JsonProcessingException e) {
+            log.error("JsonProcessingException : {}", e.getMessage(), e);
             throw new RedisException.RedisJsonProcessingException(e.getMessage());
         } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException : {}", e.getMessage(), e);
             throw new RedisException.RedisIllegalArgumentException(e.getMessage());
         }
     }
@@ -56,11 +59,11 @@ public class RedisService {
         return redisConverter.createResponse(domain, redisProductJsonDeserializer);
     }
 
-    private DeserializedRedisProduct getProduct(RedisProductRequest redisProductRequest) throws JsonProcessingException {
-        return redisTemplateManager.getProductsByMallName(redisProductRequest.getMallName());
+    private DeserializedRedisProduct getProduct(String mallName) throws JsonProcessingException {
+        return redisRepository.getProductsByMallName(mallName);
     }
 
-    public boolean validateRedisProductRequestParameter(RedisProductRequest redisProductRequest) throws IllegalArgumentException{
+    public boolean validateRedisProductRequest(RedisProductRequest redisProductRequest) throws IllegalArgumentException{
         return redisValidator.validate(redisProductRequest);
     }
 
@@ -77,7 +80,6 @@ public class RedisService {
                             .collect(Collectors.toList());
                     return shopInformation.toBuilder().product(updatedProductList).build();
                 }).collect(Collectors.toList());
-
         return deserializedRedisProduct.toBuilder().shop_list(updatedShopList).build();
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/service/RedisService.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/service/RedisService.java
@@ -2,9 +2,9 @@ package com.spring_greens.presentation.global.redis.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.spring_greens.presentation.global.exception.CommonException;
+import com.spring_greens.presentation.global.factory.converter.ifs.ConverterFactory;
 import com.spring_greens.presentation.global.redis.exception.RedisException;
 import com.spring_greens.presentation.global.redis.validation.ifs.RedisValidator;
-import com.spring_greens.presentation.global.redis.converter.ifs.RedisConverter;
 import com.spring_greens.presentation.product.dto.redis.DeserializedRedisProduct;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisProductInformation;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisShopInformation;
@@ -23,7 +23,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RedisService {
     private final RedisRepository redisRepository;
-    private final RedisConverter redisConverter;
+    private final ConverterFactory converterFactory;
+//    private final RedisConverter redisConverter;
     private final RedisValidator redisValidator;
 
     /**
@@ -56,7 +57,7 @@ public class RedisService {
     }
 
     private RedisProductResponse convertToResponse(String domain, DeserializedRedisProduct redisProductJsonDeserializer) {
-        return redisConverter.createResponse(domain, redisProductJsonDeserializer);
+        return converterFactory.getRedisConverter().createResponse(domain, redisProductJsonDeserializer);
     }
 
     private DeserializedRedisProduct getProduct(String mallName) throws JsonProcessingException {

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/validation/RedisValidatorImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/validation/RedisValidatorImpl.java
@@ -2,8 +2,8 @@ package com.spring_greens.presentation.global.redis.validation;
 
 import com.spring_greens.presentation.global.enums.Domain;
 import com.spring_greens.presentation.global.enums.Mall;
-import com.spring_greens.presentation.product.dto.redis.request.RedisProductRequest;
 import com.spring_greens.presentation.global.redis.validation.ifs.RedisValidator;
+import com.spring_greens.presentation.product.dto.redis.request.RedisProductRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -14,36 +14,35 @@ import java.util.Arrays;
 public class RedisValidatorImpl extends RedisValidator {
     @Override
     public boolean validate(RedisProductRequest redisProductRequest) {
-        // 1. 모든 값이 널인지 확인한다.
+        // 1. Check null parameter.
         if(isNull(redisProductRequest.getMallName(), redisProductRequest.getDomain())) {
-            throw new IllegalArgumentException();
+            throw new NullPointerException("All argument is null");
         }
-        // 2. 해당 도메인이 포함되어 있는지 확인한다.
+        // 2. Check correct domain parameter.
         if(!containsDomain(redisProductRequest.getDomain())) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Domain argument is illegal");
         }
-
-        // 3. 건물이 포함되어 있는지 확인한다.
+        // 3. Check correct mallName parameter.
         if(!containsMall(redisProductRequest.getMallName())) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("MallName argument is illegal");
         }
-        // 4. 널이 아니고, 유효한 도메인이면서 건물이름이 포함되어 있으면 유효하다.
+        // 4. Return true if validate is alright.
         return true;
     }
 
     @Override
-    public boolean isNull(String... parameters) {
+    protected boolean isNull(String... parameters) {
         return Arrays.stream(parameters).anyMatch(param -> param == null || param.isEmpty());
     }
 
     @Override
-    public boolean containsDomain(String domain) {
+    protected boolean containsDomain(String domain) {
         Domain[] domains = Domain.values();
         return Arrays.stream(domains).anyMatch(param -> param.getDomain().equals(domain));
     }
 
     @Override
-    public boolean containsMall(String mallName) {
+    protected boolean containsMall(String mallName) {
         Mall[] malls = Mall.values();
         return Arrays.stream(malls).anyMatch(param -> param.getMallName().equals(mallName));
     }

--- a/presentation/src/main/java/com/spring_greens/presentation/global/redis/validation/ifs/RedisValidator.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/global/redis/validation/ifs/RedisValidator.java
@@ -8,7 +8,7 @@ import com.spring_greens.presentation.global.validation.ValidationOperation;
  *
  */
 public abstract class RedisValidator implements ValidationOperation {
-    public abstract boolean isNull (String...parameters);
-    public abstract boolean containsDomain(String param);
-    public abstract boolean containsMall(String param);
+    protected abstract boolean isNull (String...parameters);
+    protected abstract boolean containsDomain(String param);
+    protected abstract boolean containsMall(String param);
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/mall/dto/response/MallDestinationResponse.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/mall/dto/response/MallDestinationResponse.java
@@ -1,12 +1,11 @@
 package com.spring_greens.presentation.mall.dto.response;
 
-import com.spring_greens.presentation.mall.dto.response.ifs.MallResponse;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
-public class MallDestinationResponse implements MallResponse {
+public class MallDestinationResponse {
     private Integer width;
     private Double latitude;
     private Double longitude;

--- a/presentation/src/main/java/com/spring_greens/presentation/mall/dto/response/MallStreetResponse.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/mall/dto/response/MallStreetResponse.java
@@ -1,7 +1,6 @@
 package com.spring_greens.presentation.mall.dto.response;
 
 import com.spring_greens.presentation.mall.dto.projection.Coordinate;
-import com.spring_greens.presentation.mall.dto.response.ifs.MallResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +8,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class MallStreetResponse implements MallResponse {
+public class MallStreetResponse {
     private Coordinate standard_position;
     private List<String> mall_name_list;
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/mall/dto/response/ifs/MallResponse.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/mall/dto/response/ifs/MallResponse.java
@@ -1,3 +1,0 @@
-package com.spring_greens.presentation.mall.dto.response.ifs;
-
-public interface MallResponse {}

--- a/presentation/src/main/java/com/spring_greens/presentation/mall/exception/MallException.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/mall/exception/MallException.java
@@ -5,8 +5,8 @@ public abstract class MallException extends RuntimeException{
         super(message);
     }
     public static class MallEntityNotFoundException extends MallException {
-        public MallEntityNotFoundException() {
-            super("IllegalArgument Exception");
+        public MallEntityNotFoundException(String message) {
+            super(message);
         }
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/mall/repository/MallRepository.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/mall/repository/MallRepository.java
@@ -15,7 +15,7 @@ public interface MallRepository extends CrudRepository<Mall, Long> {
      * This repository used Projection so Coordinate interface that contains latitude, longitude attributes.
      * @return
      */
-    @Query(value = "select name from Mall", nativeQuery = true)
+    @Query(value = "select name from Mall where id != 1", nativeQuery = true)
     List<String> findAllMallName();
 
     @Query(value = "select m.latitude as latitude, " +

--- a/presentation/src/main/java/com/spring_greens/presentation/mall/repository/MallRepository.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/mall/repository/MallRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface MallRepository extends CrudRepository<Mall, Long> {
@@ -16,17 +17,17 @@ public interface MallRepository extends CrudRepository<Mall, Long> {
      * @return
      */
     @Query(value = "select name from Mall where id != 1", nativeQuery = true)
-    List<String> findAllMallName();
+    Optional<List<String>> findAllMallName();
 
     @Query(value = "select m.latitude as latitude, " +
             "m.longitude as longitude " +
             "from Mall as m where id = 1", nativeQuery = true)
-    Coordinate findStandardCoordinate();
+    Optional<Coordinate> findStandardCoordinate();
 
     @Query(value = "select m.width as width, " +
             "m.latitude as latitude, " +
             "m.longitude as longitude " +
             "from Mall as m where m.name = :mallName", nativeQuery = true)
-    Destination findMallDestination(@Param("mallName") String mallName);
+    Optional<Destination> findMallDestination(@Param("mallName") String mallName);
 
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/mall/service/MallServiceImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/mall/service/MallServiceImpl.java
@@ -1,5 +1,6 @@
 package com.spring_greens.presentation.mall.service;
 
+import com.spring_greens.presentation.global.factory.converter.ifs.ConverterFactory;
 import com.spring_greens.presentation.mall.dto.projection.Coordinate;
 import com.spring_greens.presentation.mall.dto.projection.Destination;
 import com.spring_greens.presentation.mall.dto.request.MallRequest;
@@ -9,38 +10,56 @@ import com.spring_greens.presentation.mall.exception.MallException;
 import com.spring_greens.presentation.mall.repository.MallRepository;
 import com.spring_greens.presentation.mall.service.ifs.MallService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+
 /**
- * With this purpose in mind, we hope to give some practical education to our students. as to how is done
+ * MallService performs business logic related to shopping malls.
+ * @author itstime0809
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MallServiceImpl implements MallService {
     private final MallRepository mallRepository;
+    private final ConverterFactory converterFactory;
+
     @Override
+    @Transactional(readOnly = true)
     public MallStreetResponse getMallStreetInformation() {
-        List<String> mallNameList = mallRepository.findAllMallName();
-        Coordinate coordinate = mallRepository.findStandardCoordinate();
-        return MallStreetResponse.builder()
-                .standard_position(coordinate)
-                .mall_name_list(mallNameList).build();
+        // 1. Get mall names
+        List<String> mallNameList = mallRepository.findAllMallName()
+                .orElseThrow(() -> {
+                    log.error("Mall names not found");
+                    return new MallException.MallEntityNotFoundException("Not Found mall names");
+                });
+
+        // 2. Get coordinates
+        Coordinate coordinate = mallRepository.findStandardCoordinate()
+                .orElseThrow(() -> {
+                    log.error("Standard coordinate not found");
+                    return new MallException.MallEntityNotFoundException("Not Found standard coordinate");
+                });
+
+        return converterFactory.getMallConverter().createMallStreetResponse(coordinate, mallNameList);
     }
 
 
     @Override
+    @Transactional(readOnly = true)
     public MallDestinationResponse getMallDestinationInformation(MallRequest mallRequest) {
-        try {
-            Destination destination = mallRepository.findMallDestination(mallRequest.getName());
-            return MallDestinationResponse.builder()
-                    .width(destination.getWidth())
-                    .latitude(destination.getLatitude())
-                    .longitude(destination.getLongitude())
-                    .build();
-        } catch (NullPointerException e) {
-            throw new MallException.MallEntityNotFoundException();
-        }
+
+        // 1. Get specific mall information that contained width, latitude, longitude
+        Destination destination = mallRepository.findMallDestination(mallRequest.getName())
+                .orElseThrow(() -> {
+                    log.error("Destination Information not found");
+                    return new MallException.MallEntityNotFoundException("Not Found destination information");
+                });
+
+        return converterFactory.getMallConverter().createMallDestinationResponse(destination);
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/map/controller/MapController.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/map/controller/MapController.java
@@ -2,10 +2,11 @@ package com.spring_greens.presentation.map.controller;
 
 import com.spring_greens.presentation.global.api.ApiResponse;
 import com.spring_greens.presentation.global.controller.AbstractBaseController;
-import com.spring_greens.presentation.global.redis.service.RedisService;
+import com.spring_greens.presentation.global.factory.converter.ifs.ConverterFactory;
+import com.spring_greens.presentation.global.factory.service.ifs.ServiceFactory;
 import com.spring_greens.presentation.mall.dto.request.MallRequest;
-import com.spring_greens.presentation.mall.dto.response.ifs.MallResponse;
-import com.spring_greens.presentation.mall.service.ifs.MallService;
+import com.spring_greens.presentation.mall.dto.response.MallDestinationResponse;
+import com.spring_greens.presentation.mall.dto.response.MallStreetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,22 +18,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/map")
 public class MapController extends AbstractBaseController {
-    public MapController(MallService mallService, RedisService redisService) {
-        super(mallService, redisService);
+
+    public MapController(ConverterFactory converterFactory, ServiceFactory serviceFactory) {
+        super(converterFactory, serviceFactory);
     }
 
     @GetMapping("/get/mall/street")
     @Operation(summary = "상가거리이동 정보 제공", description = "상가거리 이동시, 기준 좌표와 마커 표시를 위한 좌표값 제공")
-    public ApiResponse<MallResponse> moveMallStreet() {
-        MallResponse mallStreetResponse = mallService.getMallStreetInformation();
+    public ApiResponse<MallStreetResponse> moveMallStreet() {
+        MallStreetResponse mallStreetResponse = serviceFactory.getMallService().getMallStreetInformation();
         return ApiResponse.ok(mallStreetResponse);
     }
 
     @GetMapping("/set/destination/{mall_name}")
     @Operation(summary = "목적지 설정", description = "목적지 설정 클릭시 상가의 너비, 위도, 경도값 제공")
-    public ApiResponse<MallResponse> setDestination(@PathVariable("mall_name") String mallName) {
-        MallRequest mallRequest = MallRequest.builder().name(mallName).build();
-        MallResponse mallDestinationResponse = mallService.getMallDestinationInformation(mallRequest);
+    public ApiResponse<MallDestinationResponse> setDestination(@PathVariable("mall_name") String mallName) {
+        MallRequest mallRequest = converterFactory.getMallConverter().createRequest(mallName);
+        MallDestinationResponse mallDestinationResponse = serviceFactory.getMallService().getMallDestinationInformation(mallRequest);
         return ApiResponse.ok(mallDestinationResponse);
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/map/converter/MallConverterImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/map/converter/MallConverterImpl.java
@@ -1,0 +1,17 @@
+package com.spring_greens.presentation.map.converter;
+
+import com.spring_greens.presentation.mall.dto.request.MallRequest;
+import com.spring_greens.presentation.map.converter.ifs.MallConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MallConverterImpl implements MallConverter {
+    @Override
+    public MallRequest createRequest() {
+        return MallRequest.builder().build();
+    }
+    @Override
+    public MallRequest createRequest(String mallName) {
+        return MallRequest.builder().name(mallName).build();
+    }
+}

--- a/presentation/src/main/java/com/spring_greens/presentation/map/converter/MallConverterImpl.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/map/converter/MallConverterImpl.java
@@ -1,8 +1,14 @@
 package com.spring_greens.presentation.map.converter;
 
+import com.spring_greens.presentation.mall.dto.projection.Coordinate;
+import com.spring_greens.presentation.mall.dto.projection.Destination;
 import com.spring_greens.presentation.mall.dto.request.MallRequest;
+import com.spring_greens.presentation.mall.dto.response.MallDestinationResponse;
+import com.spring_greens.presentation.mall.dto.response.MallStreetResponse;
 import com.spring_greens.presentation.map.converter.ifs.MallConverter;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class MallConverterImpl implements MallConverter {
@@ -13,5 +19,22 @@ public class MallConverterImpl implements MallConverter {
     @Override
     public MallRequest createRequest(String mallName) {
         return MallRequest.builder().name(mallName).build();
+    }
+
+    @Override
+    public MallStreetResponse createMallStreetResponse(Coordinate coordinate, List<String> mallNameList) {
+        return MallStreetResponse.builder()
+                .standard_position(coordinate)
+                .mall_name_list(mallNameList)
+                .build();
+    }
+
+    @Override
+    public MallDestinationResponse createMallDestinationResponse(Destination destination) {
+        return MallDestinationResponse.builder()
+                .width(destination.getWidth())
+                .latitude(destination.getLatitude())
+                .longitude(destination.getLongitude())
+                .build();
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/map/converter/ifs/MallConverter.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/map/converter/ifs/MallConverter.java
@@ -1,9 +1,18 @@
 package com.spring_greens.presentation.map.converter.ifs;
 
+import com.spring_greens.presentation.mall.dto.projection.Coordinate;
+import com.spring_greens.presentation.mall.dto.projection.Destination;
 import com.spring_greens.presentation.mall.dto.request.MallRequest;
+import com.spring_greens.presentation.mall.dto.response.MallDestinationResponse;
+import com.spring_greens.presentation.mall.dto.response.MallStreetResponse;
+
+import java.util.List;
 
 public interface MallConverter  {
 
     MallRequest createRequest();
     MallRequest createRequest(String mallName);
+
+    MallStreetResponse createMallStreetResponse(Coordinate coordinate, List<String> mallNameList);
+    MallDestinationResponse createMallDestinationResponse(Destination destination);
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/map/converter/ifs/MallConverter.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/map/converter/ifs/MallConverter.java
@@ -1,0 +1,9 @@
+package com.spring_greens.presentation.map.converter.ifs;
+
+import com.spring_greens.presentation.mall.dto.request.MallRequest;
+
+public interface MallConverter  {
+
+    MallRequest createRequest();
+    MallRequest createRequest(String mallName);
+}

--- a/presentation/src/main/java/com/spring_greens/presentation/product/deserializer/redis/RedisProductInformationJsonDeserializer.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/product/deserializer/redis/RedisProductInformationJsonDeserializer.java
@@ -5,21 +5,30 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.spring_greens.presentation.product.converter.ifs.RedisConverter;
+import com.spring_greens.presentation.global.redis.converter.ifs.RedisConverter;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisProductInformation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
 
 
+@Slf4j
 @RequiredArgsConstructor
 public class RedisProductInformationJsonDeserializer extends JsonDeserializer<DeserializedRedisProductInformation> {
     private final ObjectMapper objectMapper;
     private final RedisConverter redisConverter;
+
+
     @Override
-    public DeserializedRedisProductInformation deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-        JsonNode jsonNode = objectMapper.readTree(jsonParser);
-        return redisConverter.convertDeserializedRedisProductInformation(jsonNode);
+    public DeserializedRedisProductInformation deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(jsonParser);
+            return redisConverter.convertDeserializedRedisProductInformation(jsonNode);
+        } catch (IOException e) {
+            log.error("Error deserializing productInformation JSON: {}", e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/product/deserializer/redis/RedisShopInformationJsonDeserializer.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/product/deserializer/redis/RedisShopInformationJsonDeserializer.java
@@ -1,41 +1,49 @@
 package com.spring_greens.presentation.product.deserializer.redis;
 
-import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.spring_greens.presentation.product.converter.ifs.RedisConverter;
+import com.spring_greens.presentation.global.redis.converter.ifs.RedisConverter;
+import com.spring_greens.presentation.global.redis.exception.RedisException;
+import com.spring_greens.presentation.global.redis.converter.RedisConverterImpl;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisProductInformation;
 import com.spring_greens.presentation.product.dto.redis.deserialized.DeserializedRedisShopInformation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
 
+@Slf4j
 @RequiredArgsConstructor
 public class RedisShopInformationJsonDeserializer extends JsonDeserializer<DeserializedRedisShopInformation> {
     private final ObjectMapper objectMapper;
     private final RedisConverter redisConverter;
 
     @Override
-    public DeserializedRedisShopInformation deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException {
+    public DeserializedRedisShopInformation deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
 
-        JsonNode jsonNode = objectMapper.readTree(jsonParser);
+        try {
+            JsonNode jsonNode = objectMapper.readTree(jsonParser);
+            List<DeserializedRedisProductInformation> productInfoList = StreamSupport.stream(jsonNode.get("product").spliterator(), false)
+                    .map(productNode -> {
+                        try {
+                            return objectMapper.readValue(productNode.traverse(), DeserializedRedisProductInformation.class);
+                        } catch (IOException e) {
+                            log.error("Error deserializing productNode: {}", e.getMessage(), e);
+                            throw new RedisException.RedisIOException(e.getMessage());
+                        }
+                    })
+                    .toList();
 
-        List<DeserializedRedisProductInformation> productInfoList = StreamSupport.stream(jsonNode.get("product").spliterator(), false)
-                .map(productNode -> {
-                    try {
-                        return objectMapper.readValue(productNode.traverse(), DeserializedRedisProductInformation.class);
-                    } catch (IOException e) {
-                        throw new RuntimeException("Failed to deserialize product information", e);
-                    }
-                })
-                .toList();
-
-        return redisConverter.convertDeserializedRedisShopInformation(jsonNode, productInfoList);
+            return redisConverter.convertDeserializedRedisShopInformation(jsonNode, productInfoList);
+        } catch (IOException e) {
+            log.error("Error deserializing shopInformation JSON: {}", e.getMessage(), e);
+            throw new RedisException.RedisIOException(e.getMessage());
+        }
     }
 }

--- a/presentation/src/main/java/com/spring_greens/presentation/product/dto/redis/response/MapRedisProductResponse.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/product/dto/redis/response/MapRedisProductResponse.java
@@ -1,10 +1,11 @@
 package com.spring_greens.presentation.product.dto.redis.response;
 
 import com.spring_greens.presentation.product.dto.redis.RedisProduct;
+import com.spring_greens.presentation.product.dto.redis.response.ifs.RedisProductResponse;
 import com.spring_greens.presentation.shop.dto.information.MapRedisShopInformation;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @Getter
-public class MapRedisProductResponse extends RedisProduct<MapRedisShopInformation> implements RedisProductResponse{}
+public class MapRedisProductResponse extends RedisProduct<MapRedisShopInformation> implements RedisProductResponse {}

--- a/presentation/src/main/java/com/spring_greens/presentation/product/dto/redis/response/RedisProductResponse.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/product/dto/redis/response/RedisProductResponse.java
@@ -1,3 +1,0 @@
-package com.spring_greens.presentation.product.dto.redis.response;
-
-public interface RedisProductResponse {}

--- a/presentation/src/main/java/com/spring_greens/presentation/product/dto/redis/response/ifs/RedisProductResponse.java
+++ b/presentation/src/main/java/com/spring_greens/presentation/product/dto/redis/response/ifs/RedisProductResponse.java
@@ -1,0 +1,3 @@
+package com.spring_greens.presentation.product.dto.redis.response.ifs;
+
+public interface RedisProductResponse {}

--- a/presentation/src/main/resources/application.properties
+++ b/presentation/src/main/resources/application.properties
@@ -28,9 +28,5 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.password=${REDIS_PASSWORD}
-
-# Logging configuration
-logging.level.root=${LOGGING_LEVEL}
-
 # Server port configuration
 server.port=${SERVER_PORT}


### PR DESCRIPTION
### Before
1. AbstractBaseController가 Service 및 Converter에 대한 의존성을 전부 가지고 있었음.

2. 로깅설정 미흡.

3. 상가거리이동 API 호출시 쿼리에서 상가 이름을 전부 가지고 오게 되어 id = 1인 기준점도 가지고 오게 됨.

### After
1. AbstractBaseController는 factory를 주입받음. 추상 클래스기 때문에 service 및 converter가 각 controller에서 사용하게 되는 경우 facotory가 없는 경우 생성자를 다시 추가해야 되는 문제가 있었음. 즉 확장성에 문제가 있던 것을 해결. 각 factory들이 의존을 갖게 되고 abstractController는 factory만 의존하면 되기 때문이다.

2. slf4j + logback을 사용할 때, logback xml을 추가해서 dev에서  로깅전략을 DEBUG 레벨로 가지고 가도록 설정. 세부 사항을 설정하기 위해서 properties에서 logging level 설정을 제거.

3. 기준이 되는 정거장은 제외하고 가지고 오도록 쿼리 변경. 이것은 기준점에 대한 상가를 미정했기 때문에 임의 설정값. 

4. lombok config에서 Qualifier를 인식하지 못해 config에 임의로 설정을 추가. 

 